### PR TITLE
Add pre commit hook to repo, which checks flake8 and black formatting

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,33 @@
+exclude: '(^hera_cc_utils/data/)'
+
+repos:
+  - repo: git://github.com/pre-commit/pre-commit-hooks
+    rev: v4.0.1
+    hooks:
+      - id: trailing-whitespace
+      - id: check-added-large-files
+      - id: check-ast
+      - id: check-json
+      - id: check-merge-conflict
+      - id: check-xml
+      - id: check-yaml
+      - id: debug-statements
+      - id: end-of-file-fixer
+      - id: mixed-line-ending
+        args: ['--fix=no']
+  - repo: https://github.com/pycqa/flake8
+    rev: '3.9.2'
+    hooks:
+    - id: flake8
+      additional_dependencies:
+        - flake8-builtins
+        - flake8-comprehensions
+        - flake8-docstrings
+        - flake8-pytest
+        - flake8-rst-docstrings
+        - pep8-naming
+
+  - repo: https://github.com/psf/black
+    rev: 21.8b0
+    hooks:
+      - id: black

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -22,7 +22,9 @@ repos:
       additional_dependencies:
         - flake8-builtins
         - flake8-comprehensions
+        - flake8-copyright
         - flake8-docstrings
+        - flake8-ownership
         - flake8-pytest
         - flake8-rst-docstrings
         - pep8-naming

--- a/hera_cc_utils/__init__.py
+++ b/hera_cc_utils/__init__.py
@@ -1,4 +1,15 @@
-from .map import Map
+"""The __init__.py file for hera_cc_utils."""
+
+__all__ = [
+    "Map",
+    "Survey",
+    "Catalog",
+    "field_to_healpix",
+    "get_map_area",
+    "get_overlap_area",
+]
+
+from .mapping import Map
 from .survey import Survey
 from .catalog import Catalog
 from .util import field_to_healpix, get_map_area, get_overlap_area

--- a/hera_cc_utils/__init__.py
+++ b/hera_cc_utils/__init__.py
@@ -1,3 +1,7 @@
+# -*- coding: utf-8 -*-
+# Copyright (c) 2021 The HERA Collaboration
+# Licensed under the MIT License
+
 """The __init__.py file for hera_cc_utils."""
 
 __all__ = [

--- a/hera_cc_utils/catalog.py
+++ b/hera_cc_utils/catalog.py
@@ -1,8 +1,13 @@
-""" Utilities for dealing with galaxy/QSO catalogs. """
+# -*- coding: utf-8 -*-
+# Copyright (c) 2021 The HERA Collaboration
+# Licensed under the MIT License
+
+"""Utilities for dealing with galaxy/QSO catalogs."""
 
 import numpy as np
-from .util import deg_per_hr
 from astropy.coordinates import SkyCoord
+
+from .util import deg_per_hr
 
 _xshooter_ref = "https://ui.adsabs.harvard.edu/abs/2020ApJ...905...51S/abstract"
 
@@ -52,7 +57,7 @@ _viking = {
         "z": 6.1456,
         "ref": _xshooter_ref,
     },
-    "J2348–3054": {
+    "J2348–3054_xshooter": {
         "ra": "23h48m33.336s",
         "dec": "-30d54m10.24s",
         "z": 6.9007,
@@ -95,8 +100,6 @@ _atlas = {
         "z": 6.31,
         "ref": _atlas_ref1,
     },
-    #'J029.9915-36.5658': {'ra': '029.9915', 'dec': '-36.5658',
-    #               'z':6.02, 'ref': _atlas_ref1},
     "J332.8017−32.1036": {
         "ra": "332.8017",
         "dec": "-32.1036",
@@ -119,8 +122,6 @@ _des = {
 _yang = "https://ui.adsabs.harvard.edu/abs/2020ApJ...904...26Y/abstract"
 _decarli = "https://ui.adsabs.harvard.edu/abs/2018ApJ...854...97D/abstract"
 _other = {
-    #'J0020−3653': {'ra': '0020', 'dec': '-3653',
-    #               'z':6.834, 'ref': _yang},
     "J0142−3327": {"ra": "0142", "dec": "-3327", "z": 6.3379, "ref": _yang},
     "J0148−2826": {"ra": "0148", "dec": "-2826", "z": 6.54, "ref": _yang},
     "J2002−3013": {"ra": "2002", "dec": "-3013", "z": 6.67, "ref": _yang},
@@ -148,6 +149,17 @@ _qso_catalogs = {"viking": _viking, "panstarrs": _ps1, "atlas": _atlas, "other":
 
 
 class Catalog(object):
+    """
+    Define a class for handling QSO catalogs.
+
+    Parameters
+    ----------
+    data : str
+        The type of data to handle. Right now "qso" is the only allowed value.
+    kwargs : dict
+        Keyword arguments to save directly on the object.
+    """
+
     def __init__(self, data, **kwargs):
         self.data = data
         self.kwargs = kwargs
@@ -155,11 +167,27 @@ class Catalog(object):
     def get_all_pos(self, zmin=None):
         """
         Return a list of (RA, DEC, redshift) for all objects.
-        """
 
-        assert self.data.lower().startswith(
-            "qso"
-        ), "Only know how to do QSOs right now."
+        Parameters
+        ----------
+        zmin : float
+            The minimum redshift to include for objects in the catalog.
+
+        Returns
+        -------
+        names : list of str, shape (n_objects)
+            The names of objects in the catalog.
+        data : ndarray, shape (n_objects, 3)
+            The RA [hour angle], dec [degree], and redshift of the objects.
+
+        Raises
+        ------
+        ValueError
+            This is raised if `self.data` is not "qso", as this is the only type
+            of data we know how to handle right now.
+        """
+        if not self.data.lower().startswith("qso"):
+            raise ValueError("Only know how to do QSOs right now.")
 
         data = []
         names = []

--- a/hera_cc_utils/catalog.py
+++ b/hera_cc_utils/catalog.py
@@ -4,42 +4,79 @@ import numpy as np
 from .util import deg_per_hr
 from astropy.coordinates import SkyCoord
 
-_xshooter_ref = 'https://ui.adsabs.harvard.edu/abs/2020ApJ...905...51S/abstract'
+_xshooter_ref = "https://ui.adsabs.harvard.edu/abs/2020ApJ...905...51S/abstract"
 
 # VIKING
-_viking_ref1 = 'https://ui.adsabs.harvard.edu/abs/2013ApJ...779...24V/abstract'
-_viking_ref2 = 'https://ui.adsabs.harvard.edu/abs/2015MNRAS.453.2259V/abstract'
-_viking = \
-{
- 'J2348–3054': {'ra': '23h48m33.34s', 'dec': '-30d54m10.0s',
-                'z':6.886, 'ref': _viking_ref1},
- 'J0109–3047': {'ra': '01h09m53.13s', 'dec': '-30d47m26.3s',
-                'z':6.745, 'ref': _viking_ref1},
- 'J0305–3150': {'ra': '03h05m16.92s', 'dec': '-31d50m56.0s',
-                'z':6.604, 'ref': _viking_ref1},
- 'J0328−3253': {'ra': '03h28m35.511s', 'dec': '-32d53m22.92s',
-                'z':5.860, 'ref': _viking_ref2},
- 'J0046–2837': {'ra': '00h46m23.645s', 'dec': '-28d37m47.34s',
-                'z':5.9926, 'ref': _xshooter_ref},
- 'J2211–3206': {'ra': '22h11m12.391s', 'dec': '-32d06m12.95s',
-                'z':6.3394, 'ref': _xshooter_ref},
- 'J2318–3029': {'ra': '23h18m33.103s', 'dec': '-30d29m33.36s',
-               'z':6.1456, 'ref': _xshooter_ref},
- 'J2348–3054': {'ra': '23h48m33.336s', 'dec': '-30d54m10.24s',
-              'z':6.9007, 'ref': _xshooter_ref},
+_viking_ref1 = "https://ui.adsabs.harvard.edu/abs/2013ApJ...779...24V/abstract"
+_viking_ref2 = "https://ui.adsabs.harvard.edu/abs/2015MNRAS.453.2259V/abstract"
+_viking = {
+    "J2348–3054": {
+        "ra": "23h48m33.34s",
+        "dec": "-30d54m10.0s",
+        "z": 6.886,
+        "ref": _viking_ref1,
+    },
+    "J0109–3047": {
+        "ra": "01h09m53.13s",
+        "dec": "-30d47m26.3s",
+        "z": 6.745,
+        "ref": _viking_ref1,
+    },
+    "J0305–3150": {
+        "ra": "03h05m16.92s",
+        "dec": "-31d50m56.0s",
+        "z": 6.604,
+        "ref": _viking_ref1,
+    },
+    "J0328−3253": {
+        "ra": "03h28m35.511s",
+        "dec": "-32d53m22.92s",
+        "z": 5.860,
+        "ref": _viking_ref2,
+    },
+    "J0046–2837": {
+        "ra": "00h46m23.645s",
+        "dec": "-28d37m47.34s",
+        "z": 5.9926,
+        "ref": _xshooter_ref,
+    },
+    "J2211–3206": {
+        "ra": "22h11m12.391s",
+        "dec": "-32d06m12.95s",
+        "z": 6.3394,
+        "ref": _xshooter_ref,
+    },
+    "J2318–3029": {
+        "ra": "23h18m33.103s",
+        "dec": "-30d29m33.36s",
+        "z": 6.1456,
+        "ref": _xshooter_ref,
+    },
+    "J2348–3054": {
+        "ra": "23h48m33.336s",
+        "dec": "-30d54m10.24s",
+        "z": 6.9007,
+        "ref": _xshooter_ref,
+    },
 }
 
 # Pan-STARRS1
-_ps1_ref1 = 'https://ui.adsabs.harvard.edu/abs/2014AJ....148...14B/abstract'
-_ps1_ref2 = 'https://ui.adsabs.harvard.edu/abs/2017ApJ...849...91M/abstract'
-_ps1 = \
-{
- 'PSO 231-20': {'ra': '231.6576', 'dec': '-20.8335',
-                'z':6.5864, 'ref': _ps1_ref2},
- 'PSO J037.9706–28.8389': {'ra': '02h31m52.96s', 'dec': '-28d50m20.1s',
-               'z':5.99, 'ref': _ps1_ref1},
- 'PSO J065.4085–26.9543': {'ra': '04h21m38.049s', 'dec': '-26d57m15.61s',
-               'z':6.1871, 'ref': _xshooter_ref},
+_ps1_ref1 = "https://ui.adsabs.harvard.edu/abs/2014AJ....148...14B/abstract"
+_ps1_ref2 = "https://ui.adsabs.harvard.edu/abs/2017ApJ...849...91M/abstract"
+_ps1 = {
+    "PSO 231-20": {"ra": "231.6576", "dec": "-20.8335", "z": 6.5864, "ref": _ps1_ref2},
+    "PSO J037.9706–28.8389": {
+        "ra": "02h31m52.96s",
+        "dec": "-28d50m20.1s",
+        "z": 5.99,
+        "ref": _ps1_ref1,
+    },
+    "PSO J065.4085–26.9543": {
+        "ra": "04h21m38.049s",
+        "dec": "-26d57m15.61s",
+        "z": 6.1871,
+        "ref": _xshooter_ref,
+    },
 }
 
 # Banados+ 2016 https://ui.adsabs.harvard.edu/abs/2016ApJS..227...11B/abstract
@@ -49,56 +86,66 @@ _ps1 = \
 
 # VLT ATLAS
 # https://ui.adsabs.harvard.edu/abs/2015MNRAS.451L..16C/abstract
-_atlas_ref1 = 'https://ui.adsabs.harvard.edu/abs/2015MNRAS.451L..16C/abstract'
-_atlas_ref2 = 'https://ui.adsabs.harvard.edu/abs/2018MNRAS.478.1649C/abstract'
-_atlas = \
-{
- 'J025.6821-33.4627': {'ra': '025.6821', 'dec': '-33.4627',
-                'z':6.31, 'ref': _atlas_ref1},
- #'J029.9915-36.5658': {'ra': '029.9915', 'dec': '-36.5658',
- #               'z':6.02, 'ref': _atlas_ref1},
- 'J332.8017−32.1036': {'ra': '332.8017', 'dec': '-32.1036',
-               'z':6.32, 'ref': _atlas_ref2}
+_atlas_ref1 = "https://ui.adsabs.harvard.edu/abs/2015MNRAS.451L..16C/abstract"
+_atlas_ref2 = "https://ui.adsabs.harvard.edu/abs/2018MNRAS.478.1649C/abstract"
+_atlas = {
+    "J025.6821-33.4627": {
+        "ra": "025.6821",
+        "dec": "-33.4627",
+        "z": 6.31,
+        "ref": _atlas_ref1,
+    },
+    #'J029.9915-36.5658': {'ra': '029.9915', 'dec': '-36.5658',
+    #               'z':6.02, 'ref': _atlas_ref1},
+    "J332.8017−32.1036": {
+        "ra": "332.8017",
+        "dec": "-32.1036",
+        "z": 6.32,
+        "ref": _atlas_ref2,
+    },
 }
 
 # VHS-DES
-_ps1_vhs_des = 'https://ui.adsabs.harvard.edu/abs/2019MNRAS.487.1874R/abstract'
-_des = \
-{
- 'VDES J0020-3653': {'ra': '00h20m31.47s', 'dec': '-36d53m41.8s',
-                'z':6.5864, 'ref': _ps1_vhs_des},
+_ps1_vhs_des = "https://ui.adsabs.harvard.edu/abs/2019MNRAS.487.1874R/abstract"
+_des = {
+    "VDES J0020-3653": {
+        "ra": "00h20m31.47s",
+        "dec": "-36d53m41.8s",
+        "z": 6.5864,
+        "ref": _ps1_vhs_des,
+    },
 }
 
-_yang = 'https://ui.adsabs.harvard.edu/abs/2020ApJ...904...26Y/abstract'
-_decarli = 'https://ui.adsabs.harvard.edu/abs/2018ApJ...854...97D/abstract'
-_other = \
-{
- #'J0020−3653': {'ra': '0020', 'dec': '-3653',
- #               'z':6.834, 'ref': _yang},
- 'J0142−3327': {'ra': '0142', 'dec': '-3327',
-                'z':6.3379, 'ref': _yang},
- 'J0148−2826': {'ra': '0148', 'dec': '-2826',
-                'z':6.54, 'ref': _yang},
- 'J2002−3013': {'ra': '2002', 'dec': '-3013',
-                'z':6.67, 'ref': _yang},
- 'J2318–3113': {'ra': '23h18m18.351s', 'dec': '−31d13m46.35s',
-                'z':6.444, 'ref': _decarli},
-
+_yang = "https://ui.adsabs.harvard.edu/abs/2020ApJ...904...26Y/abstract"
+_decarli = "https://ui.adsabs.harvard.edu/abs/2018ApJ...854...97D/abstract"
+_other = {
+    #'J0020−3653': {'ra': '0020', 'dec': '-3653',
+    #               'z':6.834, 'ref': _yang},
+    "J0142−3327": {"ra": "0142", "dec": "-3327", "z": 6.3379, "ref": _yang},
+    "J0148−2826": {"ra": "0148", "dec": "-2826", "z": 6.54, "ref": _yang},
+    "J2002−3013": {"ra": "2002", "dec": "-3013", "z": 6.67, "ref": _yang},
+    "J2318–3113": {
+        "ra": "23h18m18.351s",
+        "dec": "−31d13m46.35s",
+        "z": 6.444,
+        "ref": _decarli,
+    },
 }
+
 
 def _to_decimal(s):
-    if '.' in s:
+    if "." in s:
         out = float(s)
-    elif s[0] == '-':
-        out = float(s[0:3] + '.' + s[3:])
+    elif s[0] == "-":
+        out = float(s[0:3] + "." + s[3:])
     else:
-        out = float(s[0:2] + '.' + s[2:])
+        out = float(s[0:2] + "." + s[2:])
 
     return out
 
 
-_qso_catalogs = {'viking': _viking, 'panstarrs': _ps1, 'atlas': _atlas,
-    'other': _other}
+_qso_catalogs = {"viking": _viking, "panstarrs": _ps1, "atlas": _atlas, "other": _other}
+
 
 class Catalog(object):
     def __init__(self, data, **kwargs):
@@ -110,8 +157,9 @@ class Catalog(object):
         Return a list of (RA, DEC, redshift) for all objects.
         """
 
-        assert self.data.lower().startswith('qso'), \
-            "Only know how to do QSOs right now."
+        assert self.data.lower().startswith(
+            "qso"
+        ), "Only know how to do QSOs right now."
 
         data = []
         names = []
@@ -121,25 +169,25 @@ class Catalog(object):
                 obj = _qso_catalogs[cat][element]
 
                 if zmin is not None:
-                    if obj['z'] < zmin:
+                    if obj["z"] < zmin:
                         continue
 
-                if 'h' in obj['ra']:
-                    kw = {'frame': 'icrs'}
-                    ra = obj['ra']
-                    dec = obj['dec']
+                if "h" in obj["ra"]:
+                    kw = {"frame": "icrs"}
+                    ra = obj["ra"]
+                    dec = obj["dec"]
                 else:
-                    kw = {'unit': 'degree', 'frame': 'icrs'}
-                    if len(obj['ra']) == 4:
-                        ra = _to_decimal(obj['ra']) * deg_per_hr
+                    kw = {"unit": "degree", "frame": "icrs"}
+                    if len(obj["ra"]) == 4:
+                        ra = _to_decimal(obj["ra"]) * deg_per_hr
                     else:
-                        ra = _to_decimal(obj['ra'])
+                        ra = _to_decimal(obj["ra"])
 
-                    dec = _to_decimal(obj['dec'])
+                    dec = _to_decimal(obj["dec"])
 
                 coord = SkyCoord(ra, dec, **kw)
 
                 names.append(element)
-                data.append((coord.ra.hour, coord.dec.degree, obj['z']))
+                data.append((coord.ra.hour, coord.dec.degree, obj["z"]))
 
         return names, np.array(data)

--- a/hera_cc_utils/data/__init__.py
+++ b/hera_cc_utils/data/__init__.py
@@ -1,2 +1,6 @@
+# -*- coding: utf-8 -*-
+# Copyright (c) 2021 The HERA Collaboration
+# Licensed under the MIT License
+
 """init file for hera_cc_utils/data/"""
 PATH = __path__[0]

--- a/hera_cc_utils/data/jwst/jades.py
+++ b/hera_cc_utils/data/jwst/jades.py
@@ -12,29 +12,40 @@ particularly the deep fields.
 """
 
 # Observation number in
-jades_obs = [7,8,9,10,11,12,13,14,15,16,17,18]
+jades_obs = [7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18]
 
 # V3PA is the position angle (PA) of the V3 reference axis eastward relative to
 # north when projected onto the sky.
 v3pa = [295] * 6 + [299] * 6
 
 # pre-imaging program GTO 1180
-jades = \
-    [('03h32m42.1560s', '-27d47m57.10s'),
-     ('03h32m42.6680s', '-27d47m59.64s'),
-     ('03h32m44.1300s', '-27d47m0.91s'),
-     ('03h32m44.6420s', '-27d47m3.45s'),
-     ('03h32m33.7260s', '-27d47m3.73s'),
-     ('03h32m44.2380s', '-27d47m3.73s'), # end of deep pointings 1 & 2
-     ('03h32m35.9910s', '-27d46m6.96s'),
-     ('03h32m36.5030s', '-27d46m9.50s'),
-     ('03h32m47.5440s', '-27d48m5.45s'),
-     ('03h32m44.5410s', '-27d48m52.95s'),
-     ('03h32m40.0960s', '-27d46m42.53s'),
-     ('03h32m37.0930s', '-27d47m30.03s'), # end of deep pointings 3 & 4
-     ]
+jades = [
+    ("03h32m42.1560s", "-27d47m57.10s"),
+    ("03h32m42.6680s", "-27d47m59.64s"),
+    ("03h32m44.1300s", "-27d47m0.91s"),
+    ("03h32m44.6420s", "-27d47m3.45s"),
+    ("03h32m33.7260s", "-27d47m3.73s"),
+    ("03h32m44.2380s", "-27d47m3.73s"),  # end of deep pointings 1 & 2
+    ("03h32m35.9910s", "-27d46m6.96s"),
+    ("03h32m36.5030s", "-27d46m9.50s"),
+    ("03h32m47.5440s", "-27d48m5.45s"),
+    ("03h32m44.5410s", "-27d48m52.95s"),
+    ("03h32m40.0960s", "-27d46m42.53s"),
+    ("03h32m37.0930s", "-27d47m30.03s"),  # end of deep pointings 3 & 4
+]
 
 # Position of NIRCAM on focal plane
 # V2_Ref	V3_Ref	V3_IdlYAngle	V2_1	V2_2	V2_3	V2_4	V3_1	V3_2	V3_3	V3_4
-nircam = -0.32, -492.59, -0.03, 153.16, -153.74, -152.07, 151.38, -559.27, \
-    -557.14, -426.00, -427.95
+nircam = (
+    -0.32,
+    -492.59,
+    -0.03,
+    153.16,
+    -153.74,
+    -152.07,
+    151.38,
+    -559.27,
+    -557.14,
+    -426.00,
+    -427.95,
+)

--- a/hera_cc_utils/line.py
+++ b/hera_cc_utils/line.py
@@ -2,13 +2,14 @@
 
 from astropy import constants as const
 
+
 class Line(object):
     def __init__(self, line_name, freq_rest=None, lambda_rest=None):
         """
         Initialize with frequencies in MHz or wavelengths in microns.
         """
         if freq_rest == None and lambda_rest == None:
-            raise ValueError('Must specify either rest wavelength or frequency')
+            raise ValueError("Must specify either rest wavelength or frequency")
         else:
             self.line_name = line_name
 
@@ -40,22 +41,22 @@ class Line(object):
         """
         Return the observed wavelength given the redshift
         """
-        return self.lambda_rest * (1. + z)
+        return self.lambda_rest * (1.0 + z)
 
     def z_to_freq(self, z):
         """
         Return the observed frequency given the redshift
         """
-        return self.freq_rest / (1. + z)
+        return self.freq_rest / (1.0 + z)
 
     def lambda_to_z(self, lambda_obs):
         """
         Return the redshift given the observed wavelength
         """
-        return lambda_obs / self.lambda_rest - 1.
+        return lambda_obs / self.lambda_rest - 1.0
 
     def freq_to_z(self, freq_obs):
         """
         Return the redshift given the observed frequency
         """
-        return self.freq_rest / freq_obs - 1.
+        return self.freq_rest / freq_obs - 1.0

--- a/hera_cc_utils/line.py
+++ b/hera_cc_utils/line.py
@@ -1,62 +1,157 @@
-""" Utilities for dealing with common emission lines. Thanks, Adrian! """
+# -*- coding: utf-8 -*-
+# Copyright (c) 2021 The HERA Collaboration
+# Licensed under the MIT License
+
+"""Utilities for dealing with common emission lines."""
 
 from astropy import constants as const
 
 
 class Line(object):
-    def __init__(self, line_name, freq_rest=None, lambda_rest=None):
-        """
-        Initialize with frequencies in MHz or wavelengths in microns.
-        """
-        if freq_rest == None and lambda_rest == None:
-            raise ValueError("Must specify either rest wavelength or frequency")
-        else:
-            self.line_name = line_name
+    """
+    Define an object for handling emission lines.
 
-            if freq_rest == None:
-                self.lambda_rest = lambda_rest
-                # Dividing m/s by microns gives frequencies in MHz
-                self.freq_rest = const.c.to_value() / self.lambda_rest
-            else:
-                self.freq_rest = freq_rest
-                # Dividing m/s by MHz gives wavelengths in microns
-                self.lambda_rest = const.c.to_value() / self.freq_rest
+    Parameters
+    ----------
+    line_name : str
+        The name of the line.
+    freq_rest : float
+        The rest frame emission frequency, in MHz. Cannot be specified if
+        `lambda_rest` is specified.
+    lambda_rest : float
+        The rest frame emission wavelength, in µm. Cannot be specified if
+        `freq_rest` is specified.
+
+    Raises
+    ------
+    ValueError
+        This is raised if both `freq_rest` and `lambda_rest` are specified, or
+        if neither is specified.
+    """
+
+    def __init__(self, line_name, freq_rest=None, lambda_rest=None):
+        """Initialize with frequencies in MHz or wavelengths in microns."""
+        if freq_rest is None and lambda_rest is None:
+            raise ValueError("Must specify either rest wavelength or frequency")
+        if freq_rest is not None and lambda_rest is not None:
+            raise ValueError("Cannot specify both freq_rest and lambda_rest")
+
+        self.line_name = line_name
+
+        if freq_rest is None:
+            self.lambda_rest = lambda_rest
+            # Dividing m/s by microns gives frequencies in MHz
+            self.freq_rest = const.c.to_value() / self.lambda_rest
+        else:
+            self.freq_rest = freq_rest
+            # Dividing m/s by MHz gives wavelengths in microns
+            self.lambda_rest = const.c.to_value() / self.freq_rest
 
     def get_line_name(self):
+        """
+        Get the name of the line.
+
+        Parameters
+        ----------
+        None
+
+        Returns
+        -------
+        str
+            The line name.
+        """
         return self.line_name
 
     def get_rest_lambda(self):
         """
-        Return the rest wavelength
+        Get the rest wavelength of the line.
+
+        Parameters
+        ----------
+        None
+
+        Returns
+        -------
+        float
+            The rest wavelength of the line, in µm.
         """
         return self.lambda_rest
 
     def get_rest_freq(self):
         """
-        Return the rest frequency
+        Get the rest frequency of the line.
+
+        Parameters
+        ----------
+        None
+
+        Returns
+        -------
+        float
+            The rest frequency of the line, in MHz.
         """
         return self.freq_rest
 
     def z_to_lambda(self, z):
         """
-        Return the observed wavelength given the redshift
+        Return the observed wavelength given the redshift.
+
+        Parameters
+        ----------
+        z : float
+            The redshift corresponding to the observation.
+
+        Returns
+        -------
+        float
+            The wavelength of the observed radiation, in µm.
         """
         return self.lambda_rest * (1.0 + z)
 
     def z_to_freq(self, z):
         """
-        Return the observed frequency given the redshift
+        Return the observed frequency given the redshift.
+
+        Parameters
+        ----------
+        z : float
+            The redshift corresponding to the observation
+
+        Returns
+        -------
+        float
+            The frequency of the observed radiation, in MHz.
         """
         return self.freq_rest / (1.0 + z)
 
     def lambda_to_z(self, lambda_obs):
         """
-        Return the redshift given the observed wavelength
+        Return the redshift given the observed wavelength.
+
+        Parameters
+        ----------
+        lambda_obs : float
+            The observed wavelength of the radiation, in µm.
+
+        Returns
+        -------
+        float
+            The redshift corresponding to the observation.
         """
         return lambda_obs / self.lambda_rest - 1.0
 
     def freq_to_z(self, freq_obs):
         """
-        Return the redshift given the observed frequency
+        Return the redshift given the observed frequency.
+
+        Parameters
+        ----------
+        freq_obs : float
+            The observed frequency of the radiation, in MHz.
+
+        Returns
+        -------
+        float
+            The redshift corresponding to the observation.
         """
         return self.freq_rest / freq_obs - 1.0

--- a/hera_cc_utils/map.py
+++ b/hera_cc_utils/map.py
@@ -30,34 +30,34 @@ except ImportError:
 
 deg_per_hr = 15.0
 
-map_options = ['gsm', 'roman', 'ngrst', 'euclid_south', 'euclid_fornax', 'so']
+map_options = ["gsm", "roman", "ngrst", "euclid_south", "euclid_fornax", "so"]
 
-mollview_projections = ['galactic', 'equatorial', 'celestial', 'ecliptic']
+mollview_projections = ["galactic", "equatorial", "celestial", "ecliptic"]
 
 _coords_in = {
-    'gsm': 'G',
-    'roman': 'E',
-    'ngrst': 'E',
-    'euclid_south' : 'C',
-    'euclid_fornax' : 'C',
-    'so': 'C',
+    "gsm": "G",
+    "roman": "E",
+    "ngrst": "E",
+    "euclid_south": "C",
+    "euclid_fornax": "C",
+    "so": "C",
 }
 
 _filenames = {
-    'roman': 'Roman_GRISM_mask.fits',
-    'euclid_south': 'Euclid_deep_south.fits',
-    'euclid_fornax': 'Euclid_deep_Fornax.fits',
-    'so': 'so_lat.fits',
+    "roman": "Roman_GRISM_mask.fits",
+    "euclid_south": "Euclid_deep_south.fits",
+    "euclid_fornax": "Euclid_deep_Fornax.fits",
+    "so": "so_lat.fits",
 }
 
 _stripes = {
-    'hera': (-35, -25, 0, 24),
-
+    "hera": (-35, -25, 0, 24),
     # From Aihara et al. 2018, Table 5.
-    'hsc_north': (42, 44.5, '13h20m00s', '16h40m00s'),
-    'hsc_spring': (-2, 5, '09h00m00s', '15h30m00s'),
-    'hsc_fall': (-1, 7, '22h00m00s', '02h40m00s'),
+    "hsc_north": (42, 44.5, "13h20m00s", "16h40m00s"),
+    "hsc_spring": (-2, 5, "09h00m00s", "15h30m00s"),
+    "hsc_fall": (-1, 7, "22h00m00s", "02h40m00s"),
 }
+
 
 def coords_in(data):
     if type(data) == str:
@@ -66,7 +66,8 @@ def coords_in(data):
 
     print("Assuming input map is in celestial coordinates.")
     print("Set `coords_in` by hand to 'G', 'C', or 'E' to change.")
-    return 'C'
+    return "C"
+
 
 class Map(object):
     """
@@ -86,16 +87,17 @@ class Map(object):
         Any other optional keyword arguments accepted by the map being
         generated, e.g., that can be supplied to pygsm.GlobalSkyModel.
     """
-    def __init__(self, data='gsm', freq_unit='Hz', coords_in=None,
-        nside=512, **kwargs):
+
+    def __init__(self, data="gsm", freq_unit="Hz", coords_in=None, nside=512, **kwargs):
 
         if type(data) == str:
-            assert (data in map_options) or (data in _stripes.keys()), \
-                "Unrecognized input map: {}".format(data)
+            assert (data in map_options) or (
+                data in _stripes.keys()
+            ), "Unrecognized input map: {}".format(data)
 
         if type(data) == str and data in _stripes.keys():
             self.data = field_to_healpix(*_stripes[data], nside=nside)
-            self._coords_in_ = 'C'
+            self._coords_in_ = "C"
         else:
             self.data = data
             self._coords_in_ = coords_in
@@ -105,7 +107,7 @@ class Map(object):
 
     @property
     def coords_in(self):
-        if not hasattr(self, '_coords_in'):
+        if not hasattr(self, "_coords_in"):
             if self._coords_in_ is None:
                 self._coords_in = coords_in(self.data)
             else:
@@ -115,22 +117,22 @@ class Map(object):
 
     @property
     def is_binary(self):
-        if not hasattr(self, '_is_binary'):
+        if not hasattr(self, "_is_binary"):
             if type(self.data) == np.ndarray:
                 self._is_binary = np.unique(self.data).size == 2
             else:
-                self._is_binary = self.data != 'gsm'
+                self._is_binary = self.data != "gsm"
 
         return self._is_binary
 
     @property
     def _gsm(self):
-        """ An instance of pygsm.GlobalSkyModel. """
-        if not hasattr(self, '_gsm_'):
+        """An instance of pygsm.GlobalSkyModel."""
+        if not hasattr(self, "_gsm_"):
             self._gsm_ = GlobalSkyModel(freq_unit=self.freq_unit, **self.kwargs)
         return self._gsm_
 
-    def get_map(self, freq=150e6, projection='ecliptic'):
+    def get_map(self, freq=150e6, projection="ecliptic"):
         """
         Get a map suitable for plotting.
 
@@ -142,42 +144,42 @@ class Map(object):
 
         coord_in = self.coords_in
 
-        rot_kw = {'deg': False, 'inv': True}
-        if projection == 'galactic':
-            coord_out = 'G'
-        elif projection == 'ecliptic':
-            coord_out = 'E'
-        elif projection in ['celestial', 'equatorial']:
-            coord_out = 'C'
-        elif projection in ['rectilinear', 'Robinson']:
-            coord_out = 'C'
+        rot_kw = {"deg": False, "inv": True}
+        if projection == "galactic":
+            coord_out = "G"
+        elif projection == "ecliptic":
+            coord_out = "E"
+        elif projection in ["celestial", "equatorial"]:
+            coord_out = "C"
+        elif projection in ["rectilinear", "Robinson"]:
+            coord_out = "C"
         else:
             raise ValueError("Unrecognized option for `projection`.")
 
         if type(self.data) == np.ndarray:
             raw_map = self.data
             nside = healpy.npix2nside(raw_map.size)
-        elif self.data in ['gsm']:
+        elif self.data in ["gsm"]:
             raw_map = self._gsm.generate(freq)
             nside = 512
-        elif self.data in ['roman', 'ngrst']:
-            fn = _filenames['roman']
-            raw_map = healpy.fitsfunc.read_map('{}/roman/{}'.format(PATH, fn))
+        elif self.data in ["roman", "ngrst"]:
+            fn = _filenames["roman"]
+            raw_map = healpy.fitsfunc.read_map("{}/roman/{}".format(PATH, fn))
             nside = healpy.npix2nside(raw_map.size)
-        elif self.data in ['euclid_south', 'euclid_fornax']:
+        elif self.data in ["euclid_south", "euclid_fornax"]:
             fn = _filenames[self.data]
-            raw_map = healpy.fitsfunc.read_map('{}/euclid/{}'.format(PATH, fn))
+            raw_map = healpy.fitsfunc.read_map("{}/euclid/{}".format(PATH, fn))
             nside = healpy.npix2nside(raw_map.size)
-        elif self.data == 'so':
+        elif self.data == "so":
             fn = _filenames[self.data]
-            raw_map = healpy.fitsfinc.read_map('{}/so/{}'.format(PATH, fn))
+            raw_map = healpy.fitsfinc.read_map("{}/so/{}".format(PATH, fn))
             nside = healpy.npix2nside(raw_map.size)
         elif type(self.data) == np.ndarray:
             raw_map = self.data
             nside = healpy.npix2nside(raw_map.size)
         else:
             # Could add other maps here for backdrops at some point.
-            raise NotImplementedError('help')
+            raise NotImplementedError("help")
 
         # Initialize Rotator object to transform coordinates.
         rot = healpy.Rotator(coord=[coord_in, coord_out], **rot_kw)
@@ -195,21 +197,21 @@ class Map(object):
 
         # setup RA Dec coords
 
-
         # interpolate healpix
-        if projection == 'rectilinear':
+        if projection == "rectilinear":
 
             # Interpolate onto a rectangular mesh with size (nside, nside)
-            #ra = np.linspace(-90, 270, nside)
+            # ra = np.linspace(-90, 270, nside)
             ra = np.linspace(0, 360, nside)
             dec = np.linspace(0, 180, nside)
 
             RA, DEC = np.meshgrid(ra, dec)
-#
+            #
             X, Y = RA.ravel(), DEC.ravel()
-            img = healpy.get_interp_val(map_theta_phi,
-                Y * np.pi / 180., X * np.pi / 180.)
-        elif projection == 'Robinson':
+            img = healpy.get_interp_val(
+                map_theta_phi, Y * np.pi / 180.0, X * np.pi / 180.0
+            )
+        elif projection == "Robinson":
             ra = x = np.linspace(-180, 180, nside)
             dec = y = np.linspace(-90, 90, nside)
             RA, DEC = np.meshgrid(ra, dec)
@@ -222,8 +224,18 @@ class Map(object):
 
         return img
 
-    def plot_map(self, freq=None, img=None, num=1, fig=None, ax=None,
-        fig_kwargs={}, include_cbar=True, projection='rectilinear', **kwargs):
+    def plot_map(
+        self,
+        freq=None,
+        img=None,
+        num=1,
+        fig=None,
+        ax=None,
+        fig_kwargs={},
+        include_cbar=True,
+        projection="rectilinear",
+        **kwargs
+    ):
         """
         Plot map in some coordinate system.
 
@@ -259,7 +271,7 @@ class Map(object):
         # Get image if it wasn't passed
         if img is None:
             if type(self.data) == str:
-                if self.data == 'gsm':
+                if self.data == "gsm":
                     assert freq is not None, "Must supply `img` or `freq`!"
 
             img = self.get_map(freq=freq, projection=projection)
@@ -270,7 +282,7 @@ class Map(object):
             fig = plt.figure(num=num, **fig_kwargs)
             if projection.lower() in mollview_projections:
                 rect = 0, 1, 0, 1
-                #ax = healpy.projaxes.MollweideAxes(fig=fig, rect=rect)
+                # ax = healpy.projaxes.MollweideAxes(fig=fig, rect=rect)
                 has_ax = True
             else:
                 has_ax = False
@@ -279,14 +291,17 @@ class Map(object):
         if projection.lower() in mollview_projections:
             _kwargs = {}
             _proj = None
-        elif projection.lower() == 'robinson':
+        elif projection.lower() == "robinson":
             _proj = ccrs.Robinson(central_longitude=110)
-            _kwargs = {'transform': ccrs.PlateCarree(),
-                'extent': [-180, 180, -90, 90], 'aspect': None,
-                'origin':'lower'}
-        elif projection == 'rectilinear':
+            _kwargs = {
+                "transform": ccrs.PlateCarree(),
+                "extent": [-180, 180, -90, 90],
+                "aspect": None,
+                "origin": "lower",
+            }
+        elif projection == "rectilinear":
             _proj = None
-            _kwargs = {'extent': [0, 24, -90, 90], 'aspect': 'auto'}
+            _kwargs = {"extent": [0, 24, -90, 90], "aspect": "auto"}
 
         kw = kwargs.copy()
         kw.update(_kwargs)
@@ -297,29 +312,29 @@ class Map(object):
         ##
         # Actually plot
         if projection in mollview_projections:
-            healpy.mollview(img,  **kw)
+            healpy.mollview(img, **kw)
             img = None
-        elif projection == 'rectilinear':
-            if self.is_binary and 'hatches' in kw:
-                if type(kw['hatches']) == str:
-                    tmp = ['', kw['hatches']]
-                    kw['hatches'] = tmp
+        elif projection == "rectilinear":
+            if self.is_binary and "hatches" in kw:
+                if type(kw["hatches"]) == str:
+                    tmp = ["", kw["hatches"]]
+                    kw["hatches"] = tmp
 
-                del kw['aspect']
-                kw['origin'] = 'image'
+                del kw["aspect"]
+                kw["origin"] = "image"
                 cax = ax.contourf(img, levels=1, **kw)
             else:
                 cax = ax.imshow(img, **kw)
 
             ax.set_xlim(24, 0)
             ax.set_ylim(-90, 90)
-            ax.tick_params(direction='in', color='w', size=6, labelsize=22)
-            ax.set_xlabel(r'Right Ascension [hours]', fontsize=24, labelpad=5)
-            ax.set_ylabel(r'Declination [deg]', fontsize=24, labelpad=5)
+            ax.tick_params(direction="in", color="w", size=6, labelsize=22)
+            ax.set_xlabel(r"Right Ascension [hours]", fontsize=24, labelpad=5)
+            ax.set_ylabel(r"Declination [deg]", fontsize=24, labelpad=5)
         else:
-            raise NotImplementedError('help')
+            raise NotImplementedError("help")
 
         # May need transform for subsequent over-plotting
-        proj = kwargs['transform'] if 'transform' in kwargs else None
+        proj = kwargs["transform"] if "transform" in kwargs else None
 
         return fig, ax, proj, img

--- a/hera_cc_utils/mapping.py
+++ b/hera_cc_utils/mapping.py
@@ -1,4 +1,4 @@
-""" Utilities for dealing with maps. """
+"""Utilities for dealing with maps."""
 
 import os
 import sys

--- a/hera_cc_utils/survey.py
+++ b/hera_cc_utils/survey.py
@@ -1,69 +1,135 @@
-""" Utilities for comparing k-space covered by different surveys.
-    Thanks, Adrian! """
+# -*- coding: utf-8 -*-
+# Copyright (c) 2021 The HERA Collaboration
+# Licensed under the MIT License
+
+"""Utilities for comparing k-space covered by different surveys."""
 
 import numpy as np
-from .line import Line
 import matplotlib.pyplot as plt
-from .util import line_registry
 from astropy import constants as const
 from astropy.cosmology import FlatLambdaCDM
 
+from .line import Line
+from .util import line_registry
+
 cosmo = FlatLambdaCDM(H0=70, Om0=0.3, Tcmb0=2.725)
 
-survey_registry = \
-{
- 'hera': {'target_lines': ['HI'], 'R': 1533., 'hemisphere': 'S',
-    'freq_range': [50.,200.], 'angular_res': 0.00727},
-
- 'spherex': {'target_lines': ['Ha', 'Hb', 'Lya', 'OII', 'OIII'],
-    'R': 150., 'hemisphere': 'B',
-    'lambda_range': [0.75,5.0], 'angular_res':3.0058*10**-5},
-
- 'fyst': {'target_lines': ['CII', 'CO21', 'CO32', 'CO43', 'CO54'],
-   'R': 100., 'hemisphere': 'S',
-   'freq_range': [220000., 405000.], 'angular_res':0.000193925},
-
- 'tim': {'target_lines': ['CII', 'CO32', 'CO43', 'CO54'],
-   'R': 250., 'hemisphere': 'S',
-   'freq_range': [240000., 420000.], 'angular_res':5.8178*10**-5},
-
- 'concerto': {'target_lines': ['CII', 'CO21', 'CO32', 'CO43', 'CO54'],
-   'R': 200., 'hemisphere': 'S',
-   'freq_range': [200000., 360000.], 'angular_res':5.8178*10**-5},
+survey_registry = {
+    "hera": {
+        "target_lines": ["HI"],
+        "rval": 1533.0,
+        "hemisphere": "S",
+        "freq_range": [50.0, 200.0],
+        "angular_res": 0.00727,
+    },
+    "spherex": {
+        "target_lines": ["Ha", "Hb", "Lya", "OII", "OIII"],
+        "rval": 150.0,
+        "hemisphere": "B",
+        "lambda_range": [0.75, 5.0],
+        "angular_res": 3.0058 * 1e-5,
+    },
+    "fyst": {
+        "target_lines": ["CII", "CO21", "CO32", "CO43", "CO54"],
+        "rval": 100.0,
+        "hemisphere": "S",
+        "freq_range": [220000.0, 405000.0],
+        "angular_res": 0.000193925,
+    },
+    "tim": {
+        "target_lines": ["CII", "CO32", "CO43", "CO54"],
+        "rval": 250.0,
+        "hemisphere": "S",
+        "freq_range": [240000.0, 420000.0],
+        "angular_res": 5.8178 * 1e-5,
+    },
+    "concerto": {
+        "target_lines": ["CII", "CO21", "CO32", "CO43", "CO54"],
+        "rval": 200.0,
+        "hemisphere": "S",
+        "freq_range": [200000.0, 360000.0],
+        "angular_res": 5.8178 * 1e-5,
+    },
 }
 
-survey_registry['ccatp'] = survey_registry['fyst']
+survey_registry["ccatp"] = survey_registry["fyst"]
+
 
 class Survey(object):
-    def __init__(self, survey_name, target_lines=None,
-                 freq_range=None, lambda_range=None,
-                 R=None, hemisphere=None, angular_res=None):
-        """
-        Initialize a survey
-        """
+    """
+    Define an object for handling surveys.
+
+    Parameters
+    ----------
+    survey_name : str
+        The name of the survey. List of known surveys is: hera, spherex, fyst,
+        tim, concerto.
+    target_lines : list of str
+        The lines to include in the survey. Ignored if `survey_name` matches one
+        of the known surveys.
+    freq_range : 2-element list of float
+        The range of frequencies covered by the survey, in MHz. Ignored if
+        `survey_name` matches one of the known surveys. Should not be specified
+        if `lambda_range` is specified.
+    lambda_range : 2-element list of float
+        The range of wavelengths covered by the survey, in µm. Ignored if
+        `survey_name` matches one of the known surveys. Should not be specified
+        if `freq_range` is specified.
+    rval : float
+        The resolving power "R" of the experiment. Ignored if `survey_name`
+        matches one of the known surveys.
+    hemisphere : str
+        The hemisphere the survey measures. Should be one of: "N" (north), "S"
+        (south), or "B" (both).
+    angular_res : float
+        The angular resolution of the experiment, in radians. Ignored if
+        `survey_name` matches one of the known surveys.
+
+    Raises
+    ------
+    ValueError
+        This is raised if `survey_name` is not one of the known surveys, and
+        either both `freq_range` and `lambda_range` are specified or neither is
+        specified.
+
+    """
+
+    def __init__(
+        self,
+        survey_name,
+        target_lines=None,
+        freq_range=None,
+        lambda_range=None,
+        rval=None,
+        hemisphere=None,
+        angular_res=None,
+    ):
+        """Initialize a survey."""
         self.survey_name = survey_name
 
         if survey_name in survey_registry.keys():
-
             reg = survey_registry[survey_name]
 
             # More elegant way to do this but I'm lazy
-            if 'freq_range' in reg:
-                freq_range = reg['freq_range']
-            if 'lambda_range' in reg:
-                lambda_range = reg['lambda_range']
-            if 'angular_res' in reg:
-                angular_res = reg['angular_res']
-            if 'target_lines' in reg:
-                target_lines = [Line(line, **line_registry[line]) \
-                    for line in reg['target_lines']]
-            if 'R' in reg:
-                R = reg['R']
+            if "freq_range" in reg:
+                freq_range = reg["freq_range"]
+            if "lambda_range" in reg:
+                lambda_range = reg["lambda_range"]
+            if "angular_res" in reg:
+                angular_res = reg["angular_res"]
+            if "target_lines" in reg:
+                target_lines = [
+                    Line(line, **line_registry[line]) for line in reg["target_lines"]
+                ]
+            if "rval" in reg:
+                rval = reg["rval"]
 
-        if freq_range == None and lambda_range == None:
-            raise ValueError('Must specify either wavelength or frequency range')
+        if freq_range is None and lambda_range is None:
+            raise ValueError("Must specify either wavelength or frequency range")
+        if freq_range is not None and lambda_range is not None:
+            raise ValueError("Cannot specify freq_range and lambda_range")
         else:
-            if freq_range == None:
+            if freq_range is None:
                 self.lambda_range = np.array(lambda_range)
                 # Dividing m/s by microns gives frequencies in MHz
                 self.freq_range = const.c.to_value() / self.lambda_range
@@ -76,100 +142,274 @@ class Survey(object):
         self.hemisphere = hemisphere
         self.target_lines = target_lines
         self.redshift_ranges = self.calc_redshift_ranges()
-        self.R = R
+        self.rval = rval
         kpara_max = self.calc_kpara_max()
         kpara_min = self.calc_kpara_min()
         self.kpara_range = {}
         for line in self.target_lines:
             line_name = line.get_line_name()
-            self.kpara_range[line_name] = \
-            np.array([kpara_min[line_name], kpara_max[line_name]])
+            self.kpara_range[line_name] = np.array(
+                [kpara_min[line_name], kpara_max[line_name]]
+            )
         kperp_max = self.calc_kperp_max()
         self.kperp_range = {}
         for line in self.target_lines:
             line_name = line.get_line_name()
-            self.kperp_range[line_name] = \
-            np.array([0.01, kperp_max[line_name]])
+            self.kperp_range[line_name] = np.array([0.01, kperp_max[line_name]])
 
     def get_kperp_range(self):
+        """
+        Get the k_perpendicular range covered by a survey.
+
+        Parameters
+        ----------
+        None
+
+        Returns
+        -------
+        dict of 2-element list of float
+            The minimum and maximum k_perpendicular values, in units of
+            1/Mpc. The keys of the dictionary correspond to target_lines for the
+            survey and the values are the lists of ranges.
+        """
         return self.kperp_range
 
     def get_hemisphere(self):
+        """
+        Get the hemisphere covered by a survey.
+
+        Parameters
+        ----------
+        None
+
+        Returns
+        -------
+        str
+            The hemisphere covered by the survey.
+
+        """
         return self.hemisphere
 
     def get_kpara_range(self):
+        """
+        Get the k_parallel range covered by a survey.
+
+        Parameters
+        ----------
+        None
+
+        Returns
+        -------
+        dict of 2-element list of float
+            The minimum and maximum k_parallel values, in units of 1/Mpc. The
+            keys of the dictionary correspond to target_lines for the survey and
+            the values are the lists of ranges.
+        """
         return self.kpara_range
 
     def calc_kperp_max(self):
+        """
+        Calculate the maximum k_perpendicular modes for a survey.
+
+        Parameters
+        ----------
+        None
+
+        Returns
+        -------
+        dict of float
+            The minimum k_perpendicular value for a survey, in units of
+            1/Mpc. The keys correspond to the target_lines of the survey.
+        """
         kperp_max = {}
         base_factors = np.pi / (self.angular_res * cosmo.h)
         for line in self.target_lines:
             min_z, max_z = self.redshift_ranges[line.get_line_name()]
-            kperp_max[line.get_line_name()] = \
-            base_factors / cosmo.comoving_distance(max_z).to_value()
+            kperp_max[line.get_line_name()] = (
+                base_factors / cosmo.comoving_distance(max_z).to_value()
+            )
         return kperp_max
 
     def calc_kpara_max(self):
+        """
+        Calculate the maximum k_parallel modes for a survey.
+
+        Parameters
+        ----------
+        None
+
+        Returns
+        -------
+        dict of float
+            The maximum k_parallel value for a survey, in units of 1/Mpc. The
+            keys correspond to the target_lines of the survey.
+        """
         kpara_max = {}
-        base_factors = 10**3 * self.R * np.pi * cosmo.H0.to_value() \
-                        / (const.c.to_value() * cosmo.h)
+        base_factors = (
+            10 ** 3
+            * self.rval
+            * np.pi
+            * cosmo.H0.to_value()
+            / (const.c.to_value() * cosmo.h)
+        )
         for line in self.target_lines:
             min_z, max_z = self.redshift_ranges[line.get_line_name()]
-            kpara_max[line.get_line_name()] = \
-            base_factors * cosmo.efunc(min_z) / (1 + min_z)
+            kpara_max[line.get_line_name()] = (
+                base_factors * cosmo.efunc(min_z) / (1 + min_z)
+            )
         return kpara_max
 
     def calc_kpara_min(self):
+        """
+        Calculate the minimum k_parallel modes for a survey.
+
+        Parameters
+        ----------
+        None
+
+        Returns
+        -------
+        dict of float
+            The minimum k_parallel values for a survey, in units of 1/Mpc. The
+            keys correspond to the target_lines of the survey.
+        """
         kpara_min = {}
         for line in self.target_lines:
             min_z, max_z = self.redshift_ranges[line.get_line_name()]
-            rpara_range = cosmo.comoving_distance(max_z) - cosmo.comoving_distance(min_z)
+            rpara_range = cosmo.comoving_distance(max_z) - cosmo.comoving_distance(
+                min_z
+            )
             rpara_range = rpara_range.to_value()
-            kpara_min[line.get_line_name()] = 2. * np.pi / ( rpara_range * cosmo.h)
+            kpara_min[line.get_line_name()] = 2.0 * np.pi / (rpara_range * cosmo.h)
         return kpara_min
 
     def get_survey_name(self):
+        """
+        Get the name of a survey.
+
+        Parameters
+        ----------
+        None
+
+        Returns
+        -------
+        str
+            The survey name.
+        """
         return self.survey_name
 
     def get_target_lines(self):
+        """
+        Get the targeted transition lines for a survey.
+
+        Parameters
+        ----------
+        None
+
+        Returns
+        -------
+        list of str
+            The names of the lines.
+        """
         return [line.get_line_name() for line in self.target_lines]
 
-    #def get_line_wave(self):
-    #
-    #    return [line.get_line_name() for line in self.target_lines]
-
     def get_freq_range(self):
+        """
+        Get the frequency range for a survey.
+
+        Parameters
+        ----------
+        None
+
+        Returns
+        -------
+        2-element list of float
+            The minimum and maximum frequencies of the survey, in MHz.
+        """
         return self.freq_range
 
     def get_lambda_range(self):
+        """
+        Get the wavelength range for a survey.
+
+        Parameters
+        ----------
+        None
+
+        Returns
+        -------
+        2-element list of float
+            The minimum and maximum wavelengths of the survye, in µm.
+        """
         return self.lambda_range
 
     def calc_redshift_ranges(self):
         """
-        Calculate a dictionary with the line name and the redshift range
+        Calculate a dictionary with the line name and the redshift range.
+
+        Parameters
+        ----------
+        None
+
+        Returns
+        -------
+        dict of 2-element 1d-arrays of float
+            The minimum and maximum redshift values for a survey. Dictionary
+            keys correspond to target_lines, and values are the redshift range.
         """
         redshift_ranges = {}
         for line in self.target_lines:
-            min_redshift = np.max([line.freq_to_z(np.max(self.freq_range)), 0.])
-            max_redshift = np.max([line.freq_to_z(np.min(self.freq_range)), 0.])
-            redshift_ranges[line.get_line_name()] = np.array([min_redshift, max_redshift])
+            min_redshift = np.max([line.freq_to_z(np.max(self.freq_range)), 0.0])
+            max_redshift = np.max([line.freq_to_z(np.min(self.freq_range)), 0.0])
+            redshift_ranges[line.get_line_name()] = np.array(
+                [min_redshift, max_redshift]
+            )
         return redshift_ranges
 
-    def get_redshift_ranges(self,lines='All'):
-        if lines == 'All':
+    def get_redshift_ranges(self, lines=None):
+        """
+        Get the redshift range for a survey for a particular line.
+
+        Parameters
+        ----------
+        lines : list of str, optional
+            The list of lines to get redshifts for. If `None`, then all redshift
+            ranges are returned.
+
+        Returns
+        -------
+        dict of 2-element 1d-arrays of float
+            The minimum and maximum redshift values for a survey. Dictionary
+            keys correspond to target_lines, and values are the redshift range.
+        """
+        if lines is None:
             return self.redshift_ranges
         else:
             redshift_ranges = {}
             for line in lines:
-                redshift_ranges[line.get_line_name()] = self.redshift_ranges[line.get_line_name()]
+                redshift_ranges[line.get_line_name()] = self.redshift_ranges[
+                    line.get_line_name()
+                ]
             return redshift_ranges
 
     def plot_coverage_k(self, ax=None, fig=1, **kwargs):
         """
-        Plot a rectangle in (k_perp, k_para) space for each line targeted
-        by the survey.
-        """
+        Plot in (k_perp, k_para) space for each line targeted by the survey.
 
+        Parameters
+        ----------
+        ax : matplotlib axis object, optional
+            The axis to add the plot to. If None, create a new axis.
+        fig : int, optional
+            The figure number to attach to.
+        kwargs : dict
+            The options to pass through to `matplotlib.pyplot.fill_between`.
+
+        Returns
+        -------
+        ax : matplotlib axis object
+            The axis the figure was plotted to.
+        """
         had_ax = True
         if ax is None:
             fig, ax = plt.subplots(1, 1, num=fig)
@@ -181,24 +421,42 @@ class Survey(object):
         for line in self.get_target_lines():
             ax.fill_between(kperp[line], *kpara[line], **kwargs)
 
-        ax.set_xscale('log')
-        ax.set_yscale('log')
+        ax.set_xscale("log")
+        ax.set_yscale("log")
         ax.set_xlim(1e-3, 1e2)
         ax.set_ylim(1e-3, 1e2)
 
         if not had_ax:
-            ax.set_xlabel(r'$k_\perp$ [$h$Mpc$^{-1}$]')
-            ax.set_ylabel(r'$k_\parallel$ [$h$Mpc$^{-1}$]')
+            ax.set_xlabel(r"$k_\perp$ [$h$Mpc$^{-1}$]")
+            ax.set_ylabel(r"$k_\parallel$ [$h$Mpc$^{-1}$]")
 
         return ax
 
-    def plot_coverage_z(self, ax=None, fig=1, use_labels=True, start=0,
-        **kwargs):
+    def plot_coverage_z(self, ax=None, fig=1, use_labels=True, start=0, **kwargs):
         """
-        Plot a horizontal line for each emission line targeted by survey vs.
-        redshift on the x-axis.
-        """
+        Plot the redshift coverage for each line targeted by a survey.
 
+        This method plots a horizontal line for each emission line targeted by
+        survey vs.  redshift on the x-axis.
+
+        Parameters
+        ----------
+        ax : matplotlib axis object, optional
+            The axis to add the plot to. If None, create a new axis.
+        fig : int, optional
+            The figure number to attach to.
+        use_labels : bool, optional
+            Whether to add labels to the plot.
+        start : int, optional
+            Which line to start plotting with.
+        kwargs : dict
+            The keyword arguments passed to `matplotlib.pyplot.plot`.
+
+        Returns
+        -------
+        ax : matplotlib axis object
+            The axis the figure was plotted to.
+        """
         had_ax = True
         if ax is None:
             fig, ax = plt.subplots(1, 1, num=fig)
@@ -208,15 +466,14 @@ class Survey(object):
         line_names = self.get_target_lines()
 
         for i, line in enumerate(line_names):
-            label = '{} {}'.format(self.survey_name, line) if use_labels \
-                else None
-            ax.plot(line_zs[line], [start+i]*2, label=label, **kwargs)
+            label = "{} {}".format(self.survey_name, line) if use_labels else None
+            ax.plot(line_zs[line], [start + i] * 2, label=label, **kwargs)
 
         ax.set_xlim(0, 15)
         ax.set_yticklabels([])
         ax.legend()
 
         if not had_ax:
-            ax.set_xlabel(r'$z$')
+            ax.set_xlabel(r"$z$")
 
         return ax

--- a/hera_cc_utils/util.py
+++ b/hera_cc_utils/util.py
@@ -1,27 +1,31 @@
-""" Random stuff. """
+# -*- coding: utf-8 -*-
+# Copyright (c) 2021 The HERA Collaboration
+# Licensed under the MIT License
+
+"""Define helpful utility functions."""
 
 import numpy as np
 import healpy as hp
 from astropy.coordinates import SkyCoord
 
-deg_per_hr = 15.
+deg_per_hr = 15.0
 
-line_registry = \
-{
- 'HI': {'freq_rest': 1420.405751},
- 'CII': {'lambda_rest': 157.7},
- 'Lya': {'lambda_rest': 0.121567},
- 'Ha': {'lambda_rest': 0.65645377},
- 'Hb': {'lambda_rest': 0.48613615},
- 'OII': {'lambda_rest': 0.3727},
- 'OIII': {'lambda_rest': 0.5007},
- 'CO10': {'freq_rest': 115271.208},
- 'CO21': {'freq_rest': 2*115271.208},
- 'CO32': {'freq_rest': 3*115271.208},
- 'CO43': {'freq_rest': 4*115271.208},
- 'CO54': {'freq_rest': 5*115271.208},
- 'CO65': {'freq_rest': 6*115271.208},
+line_registry = {
+    "HI": {"freq_rest": 1420.405751},
+    "CII": {"lambda_rest": 157.7},
+    "Lya": {"lambda_rest": 0.121567},
+    "Ha": {"lambda_rest": 0.65645377},
+    "Hb": {"lambda_rest": 0.48613615},
+    "OII": {"lambda_rest": 0.3727},
+    "OIII": {"lambda_rest": 0.5007},
+    "CO10": {"freq_rest": 115271.208},
+    "CO21": {"freq_rest": 2 * 115271.208},
+    "CO32": {"freq_rest": 3 * 115271.208},
+    "CO43": {"freq_rest": 4 * 115271.208},
+    "CO54": {"freq_rest": 5 * 115271.208},
+    "CO65": {"freq_rest": 6 * 115271.208},
 }
+
 
 def field_to_healpix(dec_min, dec_max, ra_min=0, ra_max=24, nside=512):
     """
@@ -29,14 +33,20 @@ def field_to_healpix(dec_min, dec_max, ra_min=0, ra_max=24, nside=512):
 
     Parameters
     ----------
-    dec_min, dec_max : int, float
+    dec_min, dec_max : int or float
         Minimum/maximum declination of stripe [deg].
-    ra_min, ra_max : int, float, str
+    ra_min, ra_max : int, float, or str
         Minimum/maximum RA of stripe. If supplied as int or float, assumed
         to be in hours. If str, interpreted as ICRS, will convert to hours.
+    nside : int
+        The nside of the HEALPix map to use.
 
+    Returns
+    -------
+    img : ndarray of bool
+        A HEALPix map of boolean type defining whether the pixel is included or
+        not.
     """
-
     # Convert nside to number of pixels
     npix = hp.nside2npix(nside)
 
@@ -49,11 +59,11 @@ def field_to_healpix(dec_min, dec_max, ra_min=0, ra_max=24, nside=512):
 
     # Convert RA limits to degrees if need be.
     if type(ra_min) == str:
-        coord_min = SkyCoord(ra_min, '00d00m00s', frame='icrs')
+        coord_min = SkyCoord(ra_min, "00d00m00s", frame="icrs")
         ra_min = coord_min.ra.hour
 
     if type(ra_max) == str:
-        coord_max = SkyCoord(ra_max, '00d00m00s', frame='icrs')
+        coord_max = SkyCoord(ra_max, "00d00m00s", frame="icrs")
         ra_max = coord_max.ra.hour
 
     # Setup a mask that tells us which pixels are in the HERA stripe.
@@ -71,6 +81,7 @@ def field_to_healpix(dec_min, dec_max, ra_min=0, ra_max=24, nside=512):
 
     return img
 
+
 def get_overlap_area(img1, img2):
     """
     Given two healpix maps, find the overlapping area in square degrees.
@@ -84,12 +95,11 @@ def get_overlap_area(img1, img2):
     img1, img2: np.ndarray
         Healpix maps (i.e., 1-D arrays).
 
-
     Returns
     -------
-    Overlapping area in square degrees.
+    float
+        Overlapping area in square degrees.
     """
-
     nside = hp.npix2nside(img1.size)
     nside2 = hp.npix2nside(img2.size)
 
@@ -102,6 +112,7 @@ def get_overlap_area(img1, img2):
     overlap = (img1 > 0) * (img2 > 0)
 
     return overlap.sum() * pix
+
 
 def get_map_area(img):
     """
@@ -118,8 +129,8 @@ def get_map_area(img):
 
     Returns
     -------
-    Survey area in square degrees.
-
+    float:
+        Survey area in square degrees.
     """
     nside = hp.npix2nside(img.size)
     pix = hp.nside2pixarea(nside, degrees=True)

--- a/scripts/test_map_gsm.py
+++ b/scripts/test_map_gsm.py
@@ -1,3 +1,7 @@
+# -*- coding: utf-8 -*-
+# Copyright (c) 2021 The HERA Collaboration
+# Licensed under the MIT License
+
 """Simple demo showing how to plot GSM."""
 
 import hera_cc_utils as hera_cc

--- a/scripts/test_map_gsm.py
+++ b/scripts/test_map_gsm.py
@@ -1,10 +1,11 @@
-""" Simple demo showing how to plot GSM. """
+"""Simple demo showing how to plot GSM."""
 
 import hera_cc_utils as hera_cc
 
 gsm = hera_cc.Map()
 
-fig1, ax1, proj1 = gsm.plot_map(freq=150e6, projection='Robinson')
+fig1, ax1, proj1 = gsm.plot_map(freq=150e6, projection="Robinson")
 
-fig2, ax2, proj2 = gsm.plot_map(freq=150e6, projection='rectilinear',
-    num=2, vmin=1e2, vmax=1e3)
+fig2, ax2, proj2 = gsm.plot_map(
+    freq=150e6, projection="rectilinear", num=2, vmin=1e2, vmax=1e3
+)

--- a/scripts/test_map_roman.py
+++ b/scripts/test_map_roman.py
@@ -1,21 +1,20 @@
-""" Simple demo showing how to plot GSM. """
+"""Simple demo showing how to plot GSM."""
 
 import healpy
 import numpy as np
 import hera_cc_utils as hera_cc
 
-proj = 'rectilinear'
+proj = "rectilinear"
 
 gsm = hera_cc.Map()
-rst = hera_cc.Map(data='roman')
+rst = hera_cc.Map(data="roman")
 
-kw = {'vmin':1e-2} if proj == 'rectilinear' else {'min':1e-2}
+kw = {"vmin": 1e-2} if proj == "rectilinear" else {"min": 1e-2}
 
 fig1, ax1, proj1, img1 = gsm.plot_map(freq=150e6, projection=proj, num=1)
 
 # Plot
-fig2, ax2, proj2, img2 = rst.plot_map(projection=proj, num=2,
-    cmap='binary', **kw)
+fig2, ax2, proj2, img2 = rst.plot_map(projection=proj, num=2, cmap="binary", **kw)
 
 
 # Just pick same nside as GSM
@@ -25,32 +24,38 @@ npix = healpy.nside2npix(nside)
 # angles in radians
 theta, phi = healpy.pix2ang(nside, np.arange(npix))
 
-deg_per_hr = 15.
+deg_per_hr = 15.0
 ra = np.rad2deg(phi) / deg_per_hr
 dec = np.rad2deg(0.5 * np.pi - theta)
 
 hera_stripe = np.logical_and(dec >= -35, dec <= -25)
 
 img = np.zeros(npix)
-img[hera_stripe==1] = 1
+img[hera_stripe == 1] = 1
 
 hera = hera_cc.Map(data=img)
-fig3, ax3, proj3, img3 = hera.plot_map(projection=proj, num=3,
-    cmap='binary_r', **kw)
+fig3, ax3, proj3, img3 = hera.plot_map(projection=proj, num=3, cmap="binary_r", **kw)
 
 
 img2[img2 < 1e-1] = 0
 
-ax1.axhline(-35, color='w')
-ax1.axhline(-25, color='w')
+ax1.axhline(-35, color="w")
+ax1.axhline(-25, color="w")
 
-_kwargs = {'extent': [-6, 18, -90, 90], 'aspect': 'auto'}
-ax1.imshow(img2, cmap='binary', alpha=0.4, **_kwargs)
+_kwargs = {"extent": [-6, 18, -90, 90], "aspect": "auto"}
+ax1.imshow(img2, cmap="binary", alpha=0.4, **_kwargs)
 
-lst_colors = ['limegreen', 'gold', 'cyan']
+lst_colors = ["limegreen", "gold", "cyan"]
 lst_cuts = [(1.25, 2.7), (4.5, 6.5), (8.5, 10.75)]
 for i, lc in enumerate(lst_cuts):
-    ax1.fill_between([lc[0], lc[1]], -34.5, -25.5, facecolor='none',
+    ax1.fill_between(
+        [lc[0], lc[1]],
+        -34.5,
+        -25.5,
+        facecolor="none",
         edgecolor=lst_colors[i],
-        alpha=1, zorder=5, lw=1.5)
-    ax1.text(lc[1]-.1, -32, "F{}".format(i + 1), fontsize=18, c='w')
+        alpha=1,
+        zorder=5,
+        lw=1.5,
+    )
+    ax1.text(lc[1] - 0.1, -32, "F{}".format(i + 1), fontsize=18, c="w")

--- a/scripts/test_map_roman.py
+++ b/scripts/test_map_roman.py
@@ -1,3 +1,7 @@
+# -*- coding: utf-8 -*-
+# Copyright (c) 2021 The HERA Collaboration
+# Licensed under the MIT License
+
 """Simple demo showing how to plot GSM."""
 
 import healpy

--- a/scripts/test_survey_fields.py
+++ b/scripts/test_survey_fields.py
@@ -1,43 +1,48 @@
-""" Simple demo showing how to plot GSM. """
+"""Simple demo showing how to plot GSM."""
 
 import numpy as np
 import hera_cc_utils as hera_cc
-from astropy import units as u
 from astropy.coordinates import SkyCoord
 
 gsm = hera_cc.Map()
 
-fig1, ax1, proj1 = gsm.plot_map(freq=150e6, projection='Robinson')
+fig1, ax1, proj1 = gsm.plot_map(freq=150e6, projection="Robinson")
 
-fig2, ax2, proj2 = gsm.plot_map(freq=150e6, projection='rectilinear',
-    num=2, vmin=1e2, vmax=1e3)
+fig2, ax2, proj2 = gsm.plot_map(
+    freq=150e6, projection="rectilinear", num=2, vmin=1e2, vmax=1e3
+)
 
-ax2.axhline(-30 - 5, color='w', ls=':', lw=1.5, zorder=1)
-ax2.axhline(-30 + 5, color='w', ls=':', lw=1.5, zorder=1)
+ax2.axhline(-30 - 5, color="w", ls=":", lw=1.5, zorder=1)
+ax2.axhline(-30 + 5, color="w", ls=":", lw=1.5, zorder=1)
 
 lst_cuts = [(1.25, 2.7), (4.5, 6.5), (8.5, 10.75)]
 for i, lst_cut in enumerate(lst_cuts):
-    ax2.fill_betweenx([-35, -25], *lst_cut, color='none', edgecolor='w')
-    ax2.annotate('field {}'.format(i+1), (np.mean(lst_cut), -24), color='w',
-        ha='center', va='bottom')
+    ax2.fill_betweenx([-35, -25], *lst_cut, color="none", edgecolor="w")
+    ax2.annotate(
+        "field {}".format(i + 1),
+        (np.mean(lst_cut), -24),
+        color="w",
+        ha="center",
+        va="bottom",
+    )
 
 ax2.set_xlim(1, 11)
 ax2.set_ylim(-40, -20)
 
 # Draw GOODS-S field
-goods_S = SkyCoord('03h32m28s', '-27d48m30s', frame='icrs')
+goods_s = SkyCoord("03h32m28s", "-27d48m30s", frame="icrs")
 
-ra, dec = goods_S.ra.hour, goods_S.dec.degree
+ra, dec = goods_s.ra.hour, goods_s.dec.degree
 
-ax2.scatter(ra, dec, marker='x', color='w')
+ax2.scatter(ra, dec, marker="x", color="w")
 
-#patch = Rectangle(xy=(ra,dec), width=0.5, height=0.5,
+# patch = Rectangle(xy=(ra,dec), width=0.5, height=0.5,
 #    facecolor='c', alpha=0.5)
-#ax.add_patch(patch)
+# ax.add_patch(patch)
 
-euclid_dff = SkyCoord('03h31m43.6s', '-28d05m18.6s', frame='icrs')
+euclid_dff = SkyCoord("03h31m43.6s", "-28d05m18.6s", frame="icrs")
 euclid_sqdeg = 20
-euclid_R = np.sqrt(10. / np.pi)
+euclid_r = np.sqrt(10.0 / np.pi)
 
 ra, dec = euclid_dff.ra.hour, euclid_dff.dec.degree
-ax2.scatter(ra, dec, color='w', marker='+')
+ax2.scatter(ra, dec, color="w", marker="+")

--- a/scripts/test_survey_fields.py
+++ b/scripts/test_survey_fields.py
@@ -1,3 +1,7 @@
+# -*- coding: utf-8 -*-
+# Copyright (c) 2021 The HERA Collaboration
+# Licensed under the MIT License
+
 """Simple demo showing how to plot GSM."""
 
 import numpy as np

--- a/setup.cfg
+++ b/setup.cfg
@@ -3,4 +3,3 @@ ignore = W503
 max-line-length = 88
 docstring-convention = numpy
 select = C,E,W,T4,B9,F,D,A,N,RST,B
-exclude = hera_cc_utils/*.py

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,6 @@
+[flake8]
+ignore = W503
+max-line-length = 88
+docstring-convention = numpy
+select = C,E,W,T4,B9,F,D,A,N,RST,B
+exclude = hera_cc_utils/*.py

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,7 @@
-#!/usr/bin/env python
 # -*- mode: python; coding: utf-8 -*-
+# Copyright (c) 2021 The HERA Collaboration
+# Licensed under the MIT license.
+
 """Define setup.py for hera_cc_utils."""
 
 from setuptools import setup, find_namespace_packages

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 # -*- mode: python; coding: utf-8 -*-
+"""Define setup.py for hera_cc_utils."""
 
 from setuptools import setup, find_namespace_packages
 
@@ -16,6 +17,7 @@ setup_args = {
     "include_package_data": True,
     "use_scm_version": True,
     "install_requires": [
+        "astropy",
         "healpy",
         "numpy",
         "matplotlib",


### PR DESCRIPTION
This PR adds a pre-commit hook to the repo, which should help keep formatting consistent throughout the repo. The pre-commit hook checks include [flake8](https://github.com/PyCQA/flake8) and [black](https://github.com/psf/black). I have also added docstrings to all public classes and functions. Though I believe them to be correct, they should be checked in detail (e.g., that the units mentioned are correct).

One top-level change this PR includes is renaming `map.py` -> `mapping.py`, to avoid a potential namespace conflict with the python builtin `map`.

For developers, in the top-level directory, please run:
```
pre-commit install
```
This may require installing pre-commit first:
```
pip install pre-commit
```

This installation will then automatically run `pre-commit` before committing files.